### PR TITLE
Halt after sending response

### DIFF
--- a/lib/epi_locator_web/plugs/require_valid_signature.ex
+++ b/lib/epi_locator_web/plugs/require_valid_signature.ex
@@ -51,14 +51,14 @@ defmodule EpiLocatorWeb.Plugs.RequireValidSignature do
 
   defp do_call(:invalid, conn) do
     conn
-    |> halt()
     |> send_resp(403, "Invalid signature")
+    |> halt()
   end
 
   defp do_call(:used, conn) do
     conn
-    |> halt()
     |> send_resp(403, "Signature already used")
+    |> halt()
   end
 
   def get_user_id(conn) do

--- a/test/epi_locator_web/controllers/signature_controller_test.exs
+++ b/test/epi_locator_web/controllers/signature_controller_test.exs
@@ -1,0 +1,17 @@
+defmodule EpiLocatorWeb.SignatureControllerTest do
+  use EpiLocatorWeb.ConnCase, async: true
+  import Mox
+
+  describe "verify" do
+    test "asdf", %{conn: conn} do
+      expect(EpiLocator.SignatureMock, :valid?, fn _, _, _ ->
+        {:error, :invalid}
+      end)
+
+      conn = post(conn, Routes.signature_path(conn, :index), %{"path" => "/", "signature" => "some-sig"})
+
+      assert conn.halted
+      assert conn.state == :sent
+    end
+  end
+end


### PR DESCRIPTION
_I think_ this will solve the following error we see in production _sometimes_:

```
Request: POST /verify
** (exit) an exception was raised:
** (Plug.Conn.AlreadySentError) the response was already sent
(plug 1.11.1) lib/plug/conn.ex:848: Plug.Conn.merge_resp_headers/2
(epi_locator 0.1.0) EpiLocatorWeb.Router.require_valid_signature/2
(epi_locator 0.1.0) lib/epi_locator_web/router.ex:1: EpiLocatorWeb.Router.__pipe_through4__/1
(phoenix 1.5.9) lib/phoenix/router.ex:347: Phoenix.Router.__call__/2
(epi_locator 0.1.0) lib/plug/error_handler.ex:65: EpiLocatorWeb.Router.call/2
(epi_locator 0.1.0) lib/epi_locator_web/endpoint.ex:1: EpiLocatorWeb.Endpoint.plug_builder_call/2
(epi_locator 0.1.0) lib/epi_locator_web/endpoint.ex:1: EpiLocatorWeb.Endpoint."call (overridable 3)"/2
(epi_locator 0.1.0) lib/epi_locator_web/endpoint.ex:1: EpiLocatorWeb.Endpoint.call/2
```
I think what was happening was that, because we were `halt`ing before `send_resp`ing that [merge_resp_headers/2](https://hexdocs.pm/plug/Plug.Conn.html#merge_resp_headers/2) via [put_secure_browser_headers/2](https://hexdocs.pm/phoenix/Phoenix.Controller.html#put_secure_browser_headers/2) (via the `:require_valid_signature` pipeline) was raising an `AlreadySentError`.

It's difficult to trace through the router though because it's a maze of macros, but it's at least worth following the guidance and halting after sending the response instead of the inverse.
